### PR TITLE
Adjust parsing to handle a variety of test cases, in particular secondary units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+blib/
+Makefile
+MYMETA.json
+MYMETA.yml
+pm_to_blib
+*.swp

--- a/US.pm
+++ b/US.pm
@@ -893,7 +893,7 @@ sub init {
             |stop
             |tra?i?le?r
             |pod
-            |p(?:ost)?\W*o(?:ffice)?\W*box
+            |(?:u\.?s)\W*p(?:ost)?\W*[0o](?:ffice)?\W*(?:box)?
             |mail\W*box
             |ship\w*
             |box)(?![a-z])            (?{ $_{sec_unit_type}   = $^N })

--- a/US.pm
+++ b/US.pm
@@ -934,7 +934,7 @@ returns false then parse_informal_address() is called.
 sub parse_location {
     my ($class, $addr) = @_;
 
-    if ($addr =~ /$Addr_Match{corner}/ios) {
+    if ($addr =~ /$Addr_Match{corner}/is) {
         return $class->parse_intersection($addr);
     }
     return $class->parse_address($addr)
@@ -958,7 +958,7 @@ sub parse_address {
     my ($class, $addr) = @_;
     local %_;
 
-    $addr =~ /$Addr_Match{address}/ios
+    $addr =~ /$Addr_Match{address}/is
         or return undef;
 
     return $class->normalize_address({ %_ });
@@ -984,7 +984,7 @@ sub parse_informal_address {
     my ($class, $addr) = @_;
     local %_;
 
-    $addr =~ /$Addr_Match{informal_address}/ios
+    $addr =~ /$Addr_Match{informal_address}/is
         or return undef;
 
     return $class->normalize_address({ %_ });
@@ -1005,7 +1005,7 @@ sub parse_intersection {
     my ($class, $addr) = @_;
     local %_;
 
-    $addr =~ /$Addr_Match{intersection}/ios
+    $addr =~ /$Addr_Match{intersection}/is
         or return undef;
 
     my %part = %_;
@@ -1015,7 +1015,7 @@ sub parse_intersection {
     # So "X & Y Streets" becomes "X Street" and "Y Street".
     if ($part{type2} && (!$part{type1} or $part{type1} eq $part{type2})) {
         my $type = $part{type2};
-        if ($type =~ s/s\W*$//ios and $type =~ /^$Addr_Match{type}$/ios) {
+        if ($type =~ s/s\W*$//is and $type =~ /^$Addr_Match{type}$/is) {
             $part{type1} = $part{type2} = $type;
         }
     }
@@ -1049,7 +1049,7 @@ sub normalize_address {
     #m/^_/ and delete $part->{$_} for keys %$part; # for debug
 
     # strip off some punctuation
-    defined($_) && s/^\s+|\s+$|[^\w\s\-\#\&]//gos for values %$part;
+    defined($_) && s/^\s+|\s+$|[^\w\s\-\#\&]//gs for values %$part;
 
     while (my ($key, $map) = each %Normalize_Map) {
         $part->{$key} = $map->{lc $part->{$key}}
@@ -1073,11 +1073,11 @@ sub normalize_address {
 
     # attempt to expand directional prefixes on place names
     $part->{city} =~ s/^($Addr_Match{dircode})\s+(?=\S)
-                      /\u$Direction_Code{uc $1} /iosx
+                      /\u$Direction_Code{uc $1} /isx
                       if $part->{city};
 
     # strip ZIP+4 (which may be missing a hyphen)
-    $part->{zip} =~ s/^(.{5}).*/$1/os if $part->{zip};
+    $part->{zip} =~ s/^(.{5}).*/$1/s if $part->{zip};
 
     return $part;
 }

--- a/US.pm
+++ b/US.pm
@@ -795,6 +795,9 @@ sub init {
     $Addr_Match{number} = qr/(\d+-?\d*)(?=\D) (?{ $_{number} = $^N })/ix,
 
     # note that expressions like [^,]+ may scan more than you expect
+    #
+    # The commented out $_{_street} concatenation is to help debug which
+    # branches we take in this regex.
     $Addr_Match{street} = qr/
         (?:
           # special case for addresses like 100 South Street

--- a/US.pm
+++ b/US.pm
@@ -893,7 +893,7 @@ sub init {
             |stop
             |tra?i?le?r
             |pod
-            |(?:u\.?s)\W*p(?:ost)?\W*[0o](?:ffice)?\W*(?:box)?
+            |(?:u\.?s)?\W*p(?:ost)?\W*[0o](?:ffice)?\W*(?:box)?
             |mail\W*box
             |ship\w*
             |box)(?![a-z])            (?{ $_{sec_unit_type}   = $^N })

--- a/US.pm
+++ b/US.pm
@@ -387,6 +387,7 @@ our %Street_Type = (
     meadow      => "mdw",
     meadows     => "mdws",
     medows      => "mdws",
+    mall        => 'mall',
     mill        => "ml",
     mills       => "mls",
     mission     => "msn",
@@ -806,7 +807,7 @@ sub init {
           # special case for addresses like 100 South Street
           (?:($Addr_Match{direct})\W+           (?{ $_{street} = $^N })
              ($Addr_Match{type})\b              (?{ $_{type}   = $^N }))
-             #(?{ $_{_street_debug}.=1 })
+            #(?{ $_{_street_debug}.=1 })
           |
           (?:($Addr_Match{direct})\W+           (?{ $_{prefix} = $^N }))?
           (?:
@@ -847,7 +848,7 @@ sub init {
             #(?{ $_{_street_debug}.=5 })
            |
             # e.g. "Main" with no street type.
-            ([^,\x23]+?)                        (?{ $_{street} = $^N; $_{type}||='' })
+            ([^,\x23\s]+?)                      (?{ $_{street} = $^N; $_{type}||='' })
             (?:[^\w,]+($Addr_Match{type})\b     (?{ $_{type}   = $^N }))?
             (?:[^\w,]+($Addr_Match{direct})\b   (?{ $_{suffix} = $^N }))?
             #(?{ $_{_street_debug}.=6 })
@@ -881,6 +882,8 @@ sub init {
             |tra?i?le?r
             |pod
             |p(?:ost)?\W*o(?:ffice)?\W*box
+            |mail\W*box
+            |ship\w*
             |box)(?![a-z])            (?{ $_{sec_unit_type}   = $^N })
         /ix;
 
@@ -913,7 +916,7 @@ sub init {
         |
         # "45th floor". We must localize sec_unit_num as we'll very often
         # backtrack out of here.
-        (\w+?)\b                     (?{ local $_{_sec_unit_num} = $^N })
+        (\d+?(?:st|nd|rd|th))\b       (?{ local $_{_sec_unit_num} = $^N })
         \W*?$Addr_Match{sec_unit_type_numbered}
         #(?{ $_{_sec_unit_debug}.=2 })
         |
@@ -925,7 +928,7 @@ sub init {
         # "FT123": sec_unit_num: "123". "FIP #567B": sec_unit_type: "#",
         # sec_unit_num: "567B".
         (?-i:[A-Z]{2,3})
-        \s*
+        [\s-]*
         (?:(\#)                      (?{ $_{sec_unit_type}   = $^N }))?
         (\w+)\b                      (?{ $_{sec_unit_num}    = $^N })
         #(?{ $_{_sec_unit_debug}.=4 })
@@ -937,7 +940,7 @@ sub init {
         |
         # "5A", "Apt 5 A"
         (?:$Addr_Match{sec_unit_type_numbered}\W* (?{ $_{sec_unit_type} = $^N }))?
-        (\d+[\s-]?[A-Z])\b           (?{ $_{sec_unit_num}    = $^N })
+        (\d+[\s-]?[a-df-mo-rt-vx-z])\b            (?{ $_{sec_unit_num}    = $^N })
         #(?{ $_{_sec_unit_debug}.=6 })
         |
         # "A5-678"

--- a/US.pm
+++ b/US.pm
@@ -875,12 +875,12 @@ sub init {
 
     # http://pe.usps.com/text/pub28/pub28c2_003.htm
     # TODO add support for those that don't require a number
-    # TODO map to standard names/abbreviations
     $Addr_Match{sec_unit_type_numbered} = qr/
           (su?i?te?
             |s?p\W*[om]\W*b?(?:ox)?
             |(?:ap|dep)(?:ar)?t(?:me?nt)?
             |ro*m
+            |flat
             |flo*r?
             |f(?:ron)?t
             |uni?t

--- a/US.pm
+++ b/US.pm
@@ -1017,7 +1017,7 @@ sub init {
     # Being non-greedy here allows us to parse "#" in unit.
     my $sep = qr/(?:\W+?|\Z)/;
 
-    $Addr_Match{informal_address_pre} = qr/
+    $Addr_Match{informal_address} = qr/
         ^
         \s*         # skip leading whitespace
         (?:$Addr_Match{sec_unit_before_street} $sep)?
@@ -1030,31 +1030,12 @@ sub init {
            $Addr_Match{street} $sep
         (?:$Addr_Match{sec_unit_after_street} $sep)?
         (?:$Addr_Match{place})
-        /ix;
-
-    $Addr_Match{informal_address_post} = qr/
         (?{ $_{number} = $_{_number} if exists $_{_number} })
         (?{ $_{city} = $_{_city} if exists $_{_city} })
         # This ugliness is so that we prefer the first unit if we parse it in
         # two spots. It matters for things like "Unit 12345 Box 678".
         (?{ $_{sec_unit_type} = $_{_sec_unit_type1} if exists $_{_sec_unit_type1} })
         (?{ $_{sec_unit_num}  = $_{_sec_unit_num1}  if exists $_{_sec_unit_num1} })
-        /ix;
-
-    $Addr_Match{informal_address} = qr/
-        $Addr_Match{informal_address_pre}
-
-        # Matching to end of string is desirable. Otherwise we can fail to
-        # fully parse things that are present yet are optional. Consider the
-        # "12 Main , Apt 3" test case.
-        $
-
-        $Addr_Match{informal_address_post}
-        /ix;
-
-    $Addr_Match{informal_address_partial} = qr/
-        $Addr_Match{informal_address_pre}
-        $Addr_Match{informal_address_post}
         /ix;
 
     $Addr_Match{intersection} = qr/^\W*
@@ -1146,14 +1127,6 @@ sub parse_informal_address {
     local %_;
 
     if ($addr =~ /$Addr_Match{informal_address}/is) {
-        return $class->normalize_address({ %_ });
-    }
-    %_ = ();
-
-    # If we can't fully match the string, fall back to a partial match. We want
-    # to try to fully match the string first as otherwise we can leave parts
-    # unmatched that do match.
-    if ($addr =~ /$Addr_Match{informal_address_partial}/is) {
         return $class->normalize_address({ %_ });
     }
 

--- a/US.pm
+++ b/US.pm
@@ -171,13 +171,14 @@ our %Direction_Code; # setup in init();
 
 
 our %Sec_Unit_Type = (
-    'p0 box'         => 'PO Box',
-    'p0'             => 'PO Box',
-    'po'             => 'PO Box',
-    'po box'         => 'PO Box',
-    'post office'    => 'PO Box',
-    'uspo'           => 'PO Box',
-    'us post office' => 'PO Box',
+    'p0 box'          => 'PO Box',
+    'p0'              => 'PO Box',
+    'po'              => 'PO Box',
+    'po box'          => 'PO Box',
+    'post office'     => 'PO Box',
+    'post office box' => 'PO Box',
+    'uspo'            => 'PO Box',
+    'us post office'  => 'PO Box',
 );
 
 =head2 %Street_Type

--- a/US.pm
+++ b/US.pm
@@ -89,7 +89,7 @@ Name of the city, town, or other locale that the address is situated in.
 =head2 state
 
 The state which the address is situated in, given as its two-letter
-postal abbreviation.  for a list of abbreviations used.
+postal abbreviation.
 
 =head2 zip
 
@@ -98,11 +98,11 @@ Five digit ZIP postal code for the address, including leading zero, if needed.
 =head2 sec_unit_type
 
 If the address includes a Secondary Unit Designator, such as a room, suite or
-appartment, the C<sec_unit_type> field will indicate the type of unit.
+apartment, the C<sec_unit_type> field will indicate the type of unit.
 
 =head2 sec_unit_num
 
-If the address includes a Secondary Unit Designator, such as a room, suite or appartment,
+If the address includes a Secondary Unit Designator, such as a room, suite or apartment,
 the C<sec_unit_num> field will indicate the number of the unit (which may not be numeric).
 
 =head1 INTERSECTION SPECIFIER
@@ -173,7 +173,7 @@ our %Direction_Code; # setup in init();
 
 Maps lowercased USPS standard street types to their canonical postal
 abbreviations as found in TIGER/Line.  See eg/get_street_abbrev.pl in
-the distrbution for how this map was generated.
+the distribution for how this map was generated.
 
 =cut
 
@@ -548,7 +548,7 @@ our %_Street_Type_Match;    # set up in init() later;
 =head2 %State_Code
 
 Maps lowercased US state and territory names to their canonical two-letter
-postal abbreviations. See eg/get_state_abbrev.pl in the distrbution
+postal abbreviations. See eg/get_state_abbrev.pl in the distribution
 for how this map was generated.
 
 =cut

--- a/US.pm
+++ b/US.pm
@@ -622,7 +622,7 @@ our %State_Code = (
 
 Maps two-digit FIPS-55 US state and territory codes (including the
 leading zero!) as found in TIGER/Line to the state's canonical two-letter
-postal abbreviation. See eg/get_state_fips.pl in the distrbution for
+postal abbreviation. See eg/get_state_fips.pl in the distribution for
 how this map was generated. Yes, I know the FIPS data also has the state
 names. Oops.
 
@@ -1276,7 +1276,7 @@ addresses (for my purposes). If you want USPS-style address standardization,
 try Scrape::USPS::ZipLookup(3pm). Be aware, however, that it scrapes a form on
 the USPS website in a way that may not be officially permitted and might break
 at any time. If this module does not do what you want, you might give the
-othersa try. All three modules are available from the CPAN.
+others a try. All three modules are available from the CPAN.
 
 You can see Geo::StreetAddress::US in action at L<http://geocoder.us/>.
 

--- a/US.pm
+++ b/US.pm
@@ -169,6 +169,17 @@ our %Directional = (
 
 our %Direction_Code; # setup in init();
 
+
+our %Sec_Unit_Type = (
+    'p0 box'         => 'PO Box',
+    'p0'             => 'PO Box',
+    'po'             => 'PO Box',
+    'po box'         => 'PO Box',
+    'post office'    => 'PO Box',
+    'uspo'           => 'PO Box',
+    'us post office' => 'PO Box',
+);
+
 =head2 %Street_Type
 
 Maps lowercased USPS standard street types to their canonical postal
@@ -703,16 +714,17 @@ our %Addr_Match; # setup in init()
 init();
 
 our %Normalize_Map = (
-    prefix  => \%Directional,
-    prefix1 => \%Directional,
-    prefix2 => \%Directional,
-    suffix  => \%Directional,
-    suffix1 => \%Directional,
-    suffix2 => \%Directional,
-    type    => \%Street_Type,
-    type1   => \%Street_Type,
-    type2   => \%Street_Type,
-    state   => \%State_Code,
+    prefix        => \%Directional,
+    prefix1       => \%Directional,
+    prefix2       => \%Directional,
+    suffix        => \%Directional,
+    suffix1       => \%Directional,
+    suffix2       => \%Directional,
+    type          => \%Street_Type,
+    type1         => \%Street_Type,
+    type2         => \%Street_Type,
+    sec_unit_type => \%Sec_Unit_Type,
+    state         => \%State_Code,
 );
 
 

--- a/US.pm
+++ b/US.pm
@@ -915,11 +915,12 @@ sub init {
         # backtrack out of here.
         (\w+?)\b                     (?{ local $_{_sec_unit_num} = $^N })
         \W*?$Addr_Match{sec_unit_type_numbered}
+        #(?{ $_{_sec_unit_debug}.=2 })
         |
         # STE 789 0123456
         $Addr_Match{sec_unit_type_numbered} \W* (?{ $_{sec_unit_type} = $^N })
         ((?:\d[\s-]*){1,10})         (?{ $_{sec_unit_num}    = $^N })
-        #(?{ $_{_sec_unit_debug}.=2 })
+        #(?{ $_{_sec_unit_debug}.=3 })
         |
         # "FT123": sec_unit_num: "123". "FIP #567B": sec_unit_type: "#",
         # sec_unit_num: "567B".
@@ -927,24 +928,24 @@ sub init {
         \s*
         (?:(\#)                      (?{ $_{sec_unit_type}   = $^N }))?
         (\w+)\b                      (?{ $_{sec_unit_num}    = $^N })
-        #(?{ $_{_sec_unit_debug}.=3 })
+        #(?{ $_{_sec_unit_debug}.=4 })
         |
         # "B2": sec_unit_num: B2, "Apt B2"
         (?:$Addr_Match{sec_unit_type_numbered}\W* (?{ $_{sec_unit_type} = $^N }))?
         ([a-z][\s-]?\d+)\b           (?{ $_{sec_unit_num}    = $^N })
-        #(?{ $_{_sec_unit_debug}.=4 })
+        #(?{ $_{_sec_unit_debug}.=5 })
         |
         # "5A", "Apt 5 A"
         (?:$Addr_Match{sec_unit_type_numbered}\W* (?{ $_{sec_unit_type} = $^N }))?
         (\d+[\s-]?[A-Z])\b           (?{ $_{sec_unit_num}    = $^N })
-        #(?{ $_{_sec_unit_debug}.=5 })
+        #(?{ $_{_sec_unit_debug}.=6 })
         |
         # "A5-678"
         ((?-i:[A-Z])\d[\s-]\d+)      (?{ $_{sec_unit_num}    = $^N })
-        #(?{ $_{_sec_unit_debug}.=6 })
+        #(?{ $_{_sec_unit_debug}.=7 })
         |
             $Addr_Match{sec_unit_type_unnumbered}
-        #(?{ $_{_sec_unit_debug}.=7 })
+        #(?{ $_{_sec_unit_debug}.=8 })
         )
         (?{ $_{sec_unit_num} = $_{_sec_unit_num} if exists $_{_sec_unit_num} })
         /ix;
@@ -957,11 +958,12 @@ sub init {
         $Addr_Match{sec_unit_before_street}
         |
         (\d{1,4}|\d{6,8}|\d{10,})\b (?{ $_{sec_unit_num} = $^N })
-        #(?{ $_{_sec_unit_debug}.=8 })
+        #(?{ $_{_sec_unit_debug}.=9 })
         |
         # "A". Don't include N, E, S, W because we'll conflict with
         # directions...
         ([a-df-mo-rt-vx-z0-9])\b    (?{ $_{sec_unit_num} = $^N })
+        #(?{ $_{_sec_unit_debug}.='A' })
         )
         (?{ $_{sec_unit_num} = $_{_sec_unit_num} if exists $_{_sec_unit_num} })
         /ix;

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -1071,7 +1071,12 @@ my %address = (
         sec_unit_type => 'Apt',
         sec_unit_num  => '3A',
     },
-
+    'Flat 123, 32 Main St.' => {
+        type          => 'St',
+        sec_unit_num  => '123',
+        street        => '32 Main',
+        sec_unit_type => 'Flat'
+    },
 );
 
 

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -657,7 +657,7 @@ my %address = (
         sec_unit_num  => '56789',
     },
     'W1234 Cty Rd FF' => {
-        street        => 'Cty Rd FF',
+        street        => 'Cty',
         type          => 'Rd',
         sec_unit_num  => 'W1234',
     },
@@ -674,7 +674,7 @@ my %address = (
     '12345                                                           NW 601st Rd.AB-7890123' => {
         number        => '12345',
         prefix        => 'NW',
-        street        => '601st RdAB', # Not ideal
+        street        => '601st',
         type          => 'Rd',
         sec_unit_num  => '7890123',
     },
@@ -708,8 +708,8 @@ my %address = (
     '1234 S. Main Mall #5678' => {
         number        => '1234',
         prefix        => 'S',
-        street        => 'Main Mall',
-        type          => '',
+        street        => 'Main',
+        type          => 'Mall',
         sec_unit_type => '#',
         sec_unit_num  => '5678',
     },
@@ -748,10 +748,10 @@ my %address = (
     '1234 NW 56th Avenue ShipMe 78901 ABC' => { # Poor
         number        => '1234',
         prefix        => 'NW',
-        street        => '56th Avenue ShipMe 78901', # Not ideal
+        street        => '56th',
         type          => 'Ave',
-        sec_unit_num  => 'C',
-        zip           => '78901',
+        sec_unit_type => 'ShipMe',
+        sec_unit_num  => '78901',
     },
     '1234 Main Drive ABC Pod A' => {
         number        => '1234',
@@ -763,14 +763,13 @@ my %address = (
     '1 N 21st Ave Hammock' => { # Poor
         number        => '1',
         prefix        => 'N',
-        street        => '21st Ave Hammock', # Not ideal
+        street        => '21st',
         type          => 'Ave',
     },
     'Ab 12 box 3456' => { # Poor
-        street        => 'Ab 12', # Maybe not ideal
+        street        => 'Ab',
         type          => '',
-        sec_unit_type => 'box',
-        sec_unit_num  => '3456',
+        sec_unit_num  => '12',
     },
     '1234 east Avenue a5' => { # Poor
         number        => '1234',
@@ -893,10 +892,10 @@ my %address = (
         type          => 'Blvd',
         sec_unit_num  => '0123456789',
     },
-    '1234 W MAIN ST APT 5 APT 5' => { # Poor
+    '1234 W MAIN ST APT 5 APT 6' => { # Poor
         number        => '1234',
         prefix        => 'W',
-        street        => 'MAIN ST APT 5', # Not ideal
+        street        => 'MAIN',
         type          => 'St',
         sec_unit_type => 'APT',
         sec_unit_num  => '5',
@@ -904,10 +903,10 @@ my %address = (
     '1234 NW 56th ST BLD A B' => { # Poor
         number        => '1234',
         prefix        => 'NW',
-        street        => '56th ST BLD A', # Not ideal
+        street        => '56th',
         type          => 'St',
         sec_unit_type => 'BLD',
-        sec_unit_num  => 'B',
+        sec_unit_num  => 'A',
     },
     '123-45 main ave # 678' => {
         number        => '123-45',
@@ -947,10 +946,10 @@ my %address = (
     },
     '123 Main St. Unit 4 AB12CD4567' => {
         number        => '123',
-        street        => 'Main St Unit 4', # Not ideal
+        street        => 'Main',
         type          => 'St',
-        sec_unit_type => '4 A', # Not ideal
-        sec_unit_num  => '12CD4567',
+        sec_unit_type => 'Unit',
+        sec_unit_num  => '4',
     },
     '123 E VALLEY BLVD' => {
         number        => '123',
@@ -966,9 +965,8 @@ my %address = (
     },
     '1234 State Route 56 N' => {
         number        => '1234',
-        street        => 'State', # Not ideal
-        type          => 'Rte',
-        sec_unit_num  => '56 N', # Not ideal
+        street        => 'State Route 56',
+        type          => 'Rte', # Ideally we could have suffix N
     },
     'apt-ab12345 6789Nw 10th St' => { # Poor
         street        => '6789', # Not ideal
@@ -1003,6 +1001,72 @@ my %address = (
         type          => 'St',
         sec_unit_type => 'Ft',
         sec_unit_num  => '345',
+    },
+    "123 E Main St, Apt 456\n123 E Main St, Apt 456" => { # Poor
+        number        => '123',
+        prefix        => 'E',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '456',
+    },
+    '12Main st' => {
+        number        => '12',
+        street        => 'Main',
+        type          => 'St',
+    },
+    '1234 N Main Avenue, Apartment 567 N/A' => {
+        number        => '1234',
+        prefix        => 'N',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_type => 'Apartment',
+        sec_unit_num  => '567',
+    },
+    '1234 E 5th Street, Apt 6789 Apartment 6789' => {
+        number        => '1234',
+        prefix        => 'E',
+        street        => '5th',
+        type          => 'St',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '6789',
+    },
+    '123main st' => {
+        number        => '123',
+        street        => 'main',
+        type          => 'St',
+    },
+    '1234 N Main Ave, Mailbox 0567' => {
+        number        => '1234',
+        prefix        => 'N',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_type => 'Mailbox',
+        sec_unit_num  => '0567',
+    },
+    '123 W 42nd St, New York, NY, United States' => {
+        number        => '123',
+        prefix        => 'W',
+        street        => '42nd',
+        type          => 'St',
+        city          => 'New York',
+        state         => 'NY',
+    },
+    '123 N Main St Boethius, TX 45678 United States' => {
+        number        => '123',
+        prefix        => 'N',
+        street        => 'Main',
+        type          => 'St',
+        city          => 'Boethius',
+        state         => 'TX',
+        zip           => '45678',
+    },
+    '12 Main St Apt 3A Apt 4B' => {
+        number        => '12',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '3A',
     },
 
 );

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -813,10 +813,6 @@ my %address = (
         type          => 'St',
         sec_unit_num  => '4A',
     },
-    'Post Office Box 12345' => {
-        sec_unit_type => 'Post Office Box',
-        sec_unit_num  => '12345',
-    },
     '1234 S Main' => {
         number        => '1234',
         prefix        => 'S',

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -356,7 +356,7 @@ my %address = (
         'number' => '1234',
         'street' => 'COUNTY HWY 60',
         'suffix' => 'E',
-        'type' => '',  # ?
+        'type'   => 'Hwy',
         'state' => 'CO'
         },
 
@@ -374,6 +374,636 @@ my %address = (
           'sec_unit_num' => '105',
           'sec_unit_type' => 'Ste'
         },
+    '123 West Main Avenue apt 9N' => {
+        number        => '123',
+        prefix        => 'W',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_type => 'apt',
+        sec_unit_num  => '9N',
+    },
+    '123 Main St 123456' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_num  => '123456',
+    },
+    '123 Main Blvd FT456' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Blvd',
+        sec_unit_num  => '456',
+        sec_unit_type => 'FT',
+    },
+    '1234 Main AV #567' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_type => '#',
+        sec_unit_num  => '567',
+    },
+    '123 County Road 456' => {
+        number        => '123',
+        street        => 'County Road 456',
+        type          => 'Rd',
+    },
+    '123 County Road 4' => {
+        number        => '123',
+        street        => 'County Road 4',
+        type          => 'Rd',
+    },
+    '123 County Road 4567' => {
+        number        => '123',
+        street        => 'County Road 4567',
+        type          => 'Rd',
+    },
+    '1234 Main Road FIP #567B' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Rd',
+        sec_unit_type => '#',
+        sec_unit_num  => '567B',
+    },
+    '1234 NW 56th ST Apt7890' => {
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th',
+        type          => 'St',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '7890',
+    },
+    '1234 Main Ave B2' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_num  => 'B2',
+    },
+    '1234 Highway 56 S' => {
+        number        => '1234',
+        street        => 'Highway 56',
+        type          => 'Hwy',
+        suffix        => 'S',
+    },
+    '123 Road 4567' => {
+        number        => '123',
+        street        => 'Road 4567',
+        type          => 'Rd',
+    },
+    '1234 NW 56th Street 789' => {
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th',
+        type          => 'St',
+        sec_unit_num  => '789',
+    },
+    '12 N. St. Boethius Blvd.' => {
+        number        => '12',
+        prefix        => 'N',
+        street        => 'St Boethius',
+        type          => 'Blvd',
+    },
+    '12 Main , Apt 3' => {
+        number        => '12',
+        street        => 'Main',
+        type          => '',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '3',
+    },
+    '1 E 24th St, Suite 567' => {
+        number        => '1',
+        prefix        => 'E',
+        street        => '24th',
+        type          => 'St',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => '567',
+    },
+    '1 E. 24th St., Suite 567' => {
+        number        => '1',
+        prefix        => 'E',
+        street        => '24th',
+        type          => 'St',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => '567',
+    },
+    '1234 Main Dr.NE. Apartment D5.' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        suffix        => 'NE',
+        sec_unit_type => 'Apartment',
+        sec_unit_num  => 'D5',
+    },
+    '12345 HIGHWAY 67 S' => {
+        number        => '12345',
+        street        => 'HIGHWAY 67',
+        type          => 'Hwy',
+        suffix        => 'S',
+    },
+    '1234 Highway 56 East' => {
+        number        => '1234',
+        street        => 'Highway 56',
+        type          => 'Hwy',
+        suffix        => 'E',
+    },
+    '1234 Main Drive, Apt 567' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '567',
+    },
+    '1234 NW 56th Street 567' => {
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th',
+        type          => 'St',
+        sec_unit_num  => '567',
+    },
+    '12 Main Place 4' => {
+        number        => '12',
+        street        => 'Main',
+        type          => 'Pl',
+        sec_unit_num  => '4',
+    },
+    '1234 LA MAIN MARINA' => {
+        number        => '1234',
+        street        => 'LA MAIN',
+        type          => 'Marina',
+    },
+    '1234 W. Main Blvd.' => {
+        number        => '1234',
+        prefix        => 'W',
+        street        => 'Main',
+        type          => 'Blvd',
+    },
+    '1234 Hwy T56 S' => {
+        number        => '1234',
+        street        => 'Hwy T56',
+        type          => 'Hwy',
+        suffix        => 'S',
+    },
+    '12345 Main St 67' => {
+        number        => '12345',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_num  => '67',
+    },
+    '123 Main Drive SPO # 4567' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'SPO #',
+        sec_unit_num  => '4567',
+    },
+    '123 Main Ave Unit 4 123 Main Ave., Unit 4' => { # Almost double
+        number        => '123',
+        street        => 'Main Ave Unit 4 123 Main', # Not great, but poor input
+        type          => 'Ave',
+        sec_unit_type => 'Unit',
+        sec_unit_num  => '4',
+    },
+    '123 E Main St., Suite A' => {
+        number        => '123',
+        prefix        => 'E',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => 'A',
+    },
+    '123 E Main St, Suite A' => {
+        number        => '123',
+        prefix        => 'E',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => 'A',
+    },
+    '1234 Main Drive, apt 567' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'apt',
+        sec_unit_num  => '567',
+    },
+    'N1234 5th Avenue' => {
+        street        => '5th',
+        type          => 'Ave',
+        sec_unit_num  => 'N1234', # Arguable
+    },
+    '123 Great Main Ct' => {
+        number        => '123',
+        street        => 'Great Main',
+        type          => 'Ct',
+    },
+    'W1234 Main rd' => {
+        street        => 'Main',
+        type          => 'Rd',
+        sec_unit_num  => 'W1234', # Arguable
+    },
+    '1234 nw cove cir.' => {
+        number        => '1234',
+        prefix        => 'nw',
+        street        => 'cove',
+        type          => 'Cir',
+    },
+    '1234 nw cove cir' => {
+        number        => '1234',
+        prefix        => 'nw',
+        street        => 'cove',
+        type          => 'Cir',
+    },
+    'N1234 MAIN LN' => {
+        street        => 'MAIN',
+        type          => 'Ln',
+        sec_unit_num  => 'N1234', # Arguable
+    },
+    '1 S.4th Ave' => {
+        number        => '1',
+        prefix        => 'S',
+        street        => '4th',
+        type          => 'Ave',
+    },
+    '1234 Main Street, Suite 567' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => '567',
+    },
+    '1234 Van Zandt County Road 5678' => {
+        number        => '1234',
+        street        => 'Van Zandt County Road 5678',
+        type          => 'Rd',
+    },
+    '123 Main Ave SW, Suite A' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Ave',
+        suffix        => 'SW',
+        sec_unit_type => 'Suite',
+        sec_unit_num  => 'A',
+    },
+    '12 Main Place 3' => {
+        number        => '12',
+        street        => 'Main',
+        type          => 'Pl',
+        sec_unit_num  => '3',
+    },
+    '1234 Main Dr, Apt 56789' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '56789',
+    },
+    'W1234 Cty Rd FF' => {
+        street        => 'Cty Rd FF',
+        type          => 'Rd',
+        sec_unit_num  => 'W1234',
+    },
+    '12345 Mainy Main Ct.' => {
+        number        => '12345',
+        street        => 'Mainy Main',
+        type          => 'Ct',
+    },
+    'S1234 Main St' => {
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_num  => 'S1234',
+    },
+    '12345                                                           NW 601st Rd.AB-7890123' => {
+        number        => '12345',
+        prefix        => 'NW',
+        street        => '601st RdAB', # Not ideal
+        type          => 'Rd',
+        sec_unit_num  => '7890123',
+    },
+    '1234 Main Dr, 56' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_num  => '56',
+    },
+    '1234 Main Circle # 5' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Cir',
+        sec_unit_type => '#',
+        sec_unit_num  => '5',
+    },
+    '123 Main Ave.#4A' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_type => '#',
+        sec_unit_num  => '4A',
+    },
+    '1234 Main #56' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => '',
+        sec_unit_type => '#',
+        sec_unit_num  => '56',
+    },
+    '1234 S. Main Mall #5678' => {
+        number        => '1234',
+        prefix        => 'S',
+        street        => 'Main Mall',
+        type          => '',
+        sec_unit_type => '#',
+        sec_unit_num  => '5678',
+    },
+    'Post Office Box 12345' => { # Poor
+        street        => 'Post Office',
+        type          => '',
+        sec_unit_type => 'Box',
+        sec_unit_num  => '12345',
+    },
+    'Unit 12345 Box 678' => { # Poor
+        street        => 'Box',
+        type          => '',
+        sec_unit_type => 'Unit',
+        sec_unit_num  => '12345',
+    },
+    'PO Box 1234' => { # Poor
+        sec_unit_type => 'PO Box',
+        sec_unit_num  => '1234',
+    },
+    '1234 West Main Drive 5A' => {
+        number        => '1234',
+        prefix        => 'W',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_num  => '5A',
+    },
+    '123 Main Pl 45A' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Pl',
+        sec_unit_num  => '45A',
+    },
+    # Problematic. We require zip to come at end, so ABC confuses things in
+    # that regard. ShipMe could presumably be treated as a unit, but even that
+    # seems arguable.
+    '1234 NW 56th Avenue ShipMe 78901 ABC' => { # Poor
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th Avenue ShipMe 78901', # Not ideal
+        type          => 'Ave',
+        sec_unit_num  => 'C',
+        zip           => '78901',
+    },
+    '1234 Main Drive ABC Pod A' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'Pod',
+        sec_unit_num  => 'A',
+    },
+    '1 N 21st Ave Hammock' => { # Poor
+        number        => '1',
+        prefix        => 'N',
+        street        => '21st Ave Hammock', # Not ideal
+        type          => 'Ave',
+    },
+    'Ab 12 box 3456' => { # Poor
+        street        => 'Ab 12', # Maybe not ideal
+        type          => '',
+        sec_unit_type => 'box',
+        sec_unit_num  => '3456',
+    },
+    '1234 east Avenue a5' => { # Poor
+        number        => '1234',
+        street        => 'east',
+        type          => 'Ave',
+        sec_unit_num  => 'a5',
+    },
+    '1234 N Main Rd A5-678' => {
+        number        => '1234',
+        prefix        => 'N',
+        street        => 'Main',
+        type          => 'Rd',
+        sec_unit_num  => 'A5-678',
+    },
+    '12345 NW 61ST ST STE 789 0123456' => { # Poor
+        number        => '12345',
+        prefix        => 'NW',
+        street        => '61ST',
+        type          => 'St',
+        sec_unit_type => 'STE', # Suite
+        sec_unit_num  => '789 0123456',
+    },
+    '12345 co rd 14' => {
+        number        => '12345',
+        street        => 'co rd 14',
+        type          => 'Rd',
+    },
+    '123 E. Ave. A-4' => {
+        number        => '123',
+        street        => 'E',
+        type          => 'Ave',
+        sec_unit_num  => 'A-4',
+    },
+    '123 N Main Street, 4A' => {
+        number        => '123',
+        prefix        => 'N',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_num  => '4A',
+    },
+    'Post Office Box 12345' => {
+        sec_unit_type => 'Post Office Box',
+        sec_unit_num  => '12345',
+    },
+    '1234 S Main' => {
+        number        => '1234',
+        prefix        => 'S',
+        street        => 'Main',
+        type          => '',
+    },
+    '1234 Main Dr Apt 5 A' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '5 A',
+    },
+    '123 Main Pl 45a' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Pl',
+        sec_unit_num  => '45a',
+    },
+    '1234 E Farm Rd 567' => {
+        number        => '1234',
+        prefix        => 'E',
+        street        => 'Farm Rd 567',
+        type          => 'Rd',
+    },
+    '1234 Ga hwy 567' => {
+        number        => '1234',
+        street        => 'Ga hwy 567',
+        type          => 'Hwy',
+    },
+    '123 42nd Avenue Southeast, A' => {
+        number        => '123',
+        street        => '42nd',
+        type          => 'Ave',
+        suffix        => 'SE',
+        sec_unit_num  => 'A',
+    },
+    '123 Main Ave, 45th Floor' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_num  => '45th',
+        sec_unit_type => 'Floor',
+    },
+    '123 Main Ave 4a' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Ave',
+        sec_unit_num  => '4a',
+    },
+    # Ideally we could treat Big Beach as city and pull zipcode. However there
+    # are issues doing that as it is easy to confuse them with street names and
+    # vice versa.
+    '1234 Main Blvd, Big Beach, 56789' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Blvd',
+    },
+    '1234  Main Drive 567, 1234  Main Drive567' => { # Poor
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Dr',
+        sec_unit_num  => '567',
+    },
+    '12345 N 63rd Ave #7890 12345 N 63rd Ave #7890' => { # Poor
+        number        => '12345',
+        prefix        => 'N',
+        street        => '63rd Ave #7890 12345 N 63rd', # Not ideal
+        type          => 'Ave',
+        sec_unit_type => '#',
+        sec_unit_num  => '7890',
+    },
+    '123 Main Blvd AB0123456789' => {
+        number        => '123',
+        street        => 'Main',
+        type          => 'Blvd',
+        sec_unit_num  => '0123456789',
+    },
+    '1234 W MAIN ST APT 5 APT 5' => { # Poor
+        number        => '1234',
+        prefix        => 'W',
+        street        => 'MAIN ST APT 5', # Not ideal
+        type          => 'St',
+        sec_unit_type => 'APT',
+        sec_unit_num  => '5',
+    },
+    '1234 NW 56th ST BLD A B' => { # Poor
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th ST BLD A', # Not ideal
+        type          => 'St',
+        sec_unit_type => 'BLD',
+        sec_unit_num  => 'B',
+    },
+    '123-45 main ave # 678' => {
+        number        => '123-45',
+        street        => 'main',
+        type          => 'Ave',
+        sec_unit_type => '#',
+        sec_unit_num  => '678',
+    },
+    '1234 Main Rd NW Apt 567 A' => {
+        number        => '1234',
+        street        => 'Main',
+        type          => 'Rd',
+        suffix        => 'NW',
+        sec_unit_type => 'Apt',
+        sec_unit_num  => '567 A',
+    },
+    '1234 State Route 56-A' => {
+        number        => '1234',
+        street        => 'State Route 56-A',
+        type          => 'Rte',
+    },
+    '1234 N Main Island Dr Suit A' => { # Typo in suite
+        number        => '1234',
+        prefix        => 'N',
+        street        => 'Main Island',
+        type          => 'Dr',
+        sec_unit_type => 'Suit',
+        sec_unit_num  => 'A',
+    },
+    '1234 NW 56th street, Suit, ab7' => { # Poor
+        number        => '1234',
+        prefix        => 'NW',
+        street        => '56th',
+        type          => 'St',
+        sec_unit_type => 'Suit',
+        sec_unit_num  => 'ab7',
+    },
+    '123 Main St. Unit 4 AB12CD4567' => {
+        number        => '123',
+        street        => 'Main St Unit 4', # Not ideal
+        type          => 'St',
+        sec_unit_type => '4 A', # Not ideal
+        sec_unit_num  => '12CD4567',
+    },
+    '123 E VALLEY BLVD' => {
+        number        => '123',
+        street        => 'E', # Not ideal
+        type          => 'Vly', # Not ideal
+        sec_unit_num  => 'D', # Not ideal
+    },
+    '123 HIGHWAY 45S' => {
+        number        => '123',
+        street        => 'HIGHWAY 45',
+        type          => 'Hwy',
+        suffix        => 'S',
+    },
+    '1234 State Route 56 N' => {
+        number        => '1234',
+        street        => 'State', # Not ideal
+        type          => 'Rte',
+        sec_unit_num  => '56 N', # Not ideal
+    },
+    'apt-ab12345 6789Nw 10th St' => { # Poor
+        street        => '6789', # Not ideal
+        type          => '', # Not ideal
+        suffix        => 'Nw', # Not ideal
+        sec_unit_type => 'apt',
+        sec_unit_num  => 'ab12345',
+    },
+    'P o box 1234' => {
+        sec_unit_type => 'P o box',
+        sec_unit_num  => '1234',
+    },
+    '1234 SR 56 City Fl 78901' => {
+        number        => '1234',
+        street        => 'SR',
+        type          => '',
+        sec_unit_num  => '56',
+        city          => 'City',
+        state         => 'Fl',
+        zip           => '78901',
+    },
+    '1 Main Street Ft#23' => {
+        number        => '1',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Ft',
+        sec_unit_num  => '23',
+    },
+    '12 Main st Ft#345' => {
+        number        => '12',
+        street        => 'Main',
+        type          => 'St',
+        sec_unit_type => 'Ft',
+        sec_unit_num  => '345',
+    },
 
 );
 

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -715,7 +715,7 @@ my %address = (
     },
     'Post Office Box 12345' => {
         sec_unit_num => '12345',
-        sec_unit_type => 'Post Office Box',
+        sec_unit_type => 'PO Box',
     },
     'Unit 12345 Box 678' => { # Poor
         street        => 'Box',

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -1,8 +1,8 @@
 use blib;
-use Test::More;
 use strict;
 use warnings;
-use Data::Dumper;
+use Data::Dumper qw( Dumper );
+use Test::More;
 
 use_ok( "Geo::StreetAddress::US" );
 

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -714,10 +714,9 @@ my %address = (
         sec_unit_num  => '5678',
     },
     'Post Office Box 12345' => { # Poor
-        street        => 'Post Office',
+        street        => 'Post',
         type          => '',
-        sec_unit_type => 'Box',
-        sec_unit_num  => '12345',
+        sec_unit_type => 'Office',
     },
     'Unit 12345 Box 678' => { # Poor
         street        => 'Box',
@@ -725,7 +724,11 @@ my %address = (
         sec_unit_type => 'Unit',
         sec_unit_num  => '12345',
     },
-    'PO Box 1234' => { # Poor
+    'PO Box 1234' => {
+        sec_unit_type => 'PO Box',
+        sec_unit_num  => '1234',
+    },
+    'P.O. 1234' => {
         sec_unit_type => 'PO Box',
         sec_unit_num  => '1234',
     },

--- a/t/01_parser.t
+++ b/t/01_parser.t
@@ -713,10 +713,9 @@ my %address = (
         sec_unit_type => '#',
         sec_unit_num  => '5678',
     },
-    'Post Office Box 12345' => { # Poor
-        street        => 'Post',
-        type          => '',
-        sec_unit_type => 'Office',
+    'Post Office Box 12345' => {
+        sec_unit_num => '12345',
+        sec_unit_type => 'Post Office Box',
     },
     'Unit 12345 Box 678' => { # Poor
         street        => 'Box',


### PR DESCRIPTION
Hello!

This makes fairly large changes to the regexes. My primary motivation is to better parse secondary unit types and numbers. I've included a number of new test cases.

I realize the changes are a bit ugly and probably brittle in some ways, but I thought I'd send this anyway. I've run them against a larger set of data and by and large it seems an improvement.

One thought I had while working on this was that it might be nice to localize all of the assignments to `%_`. As you can see, I did that in a few spots as I found it helpful (and in a few cases, required). Doing this everywhere could make the behaviour more understandable, as right now I believe some of what we parse comes out of branches we backtrack out of.

Thank you!